### PR TITLE
only set certificateID if it is present in the response

### DIFF
--- a/lib/Util.php
+++ b/lib/Util.php
@@ -224,7 +224,7 @@ class Util
                 ->setOrderNumber($arr['orderNumber'])
                 ->setTotalCost($arr['totalCost'])
                 ->setRequestQuery($arr['requestQuery']);
-            
+
             if (isset($arr['uniqueValue'])) {
                 $result->setUniqueValue($arr['uniqueValue']);
             }
@@ -303,9 +303,11 @@ class Util
         if ($arr['errorCode'] == 0) {
             $result = new AutoReplaceResult();
 
-            $result
-                ->setCertificateID($arr['certificateID'])
-                ->setExpectedDeliveryTime($arr['expectedDeliveryTime']);
+            $result->setExpectedDeliveryTime($arr['expectedDeliveryTime']);
+
+            if (isset($arr['certificateID'])) {
+                $result->setCertificateID($arr['certificateID']);
+            }
 
             if (isset($arr['uniqueValue'])) {
                 $result->setUniqueValue($arr['uniqueValue']);
@@ -408,10 +410,10 @@ class Util
             $result = new CollectSslResult();
 
             $this->fill($result, $arr, array('notBefore', 'notAfter'));
-            
+
             /*
              * Comodo does not provide these data, when not a EV certificate (Bug?). So we fill this manually to "not required".
-             * 
+             *
              * https://secure.comodo.net/api/pdf/webhostreseller/sslcertificates/CollectSSL%20v1.17.pdf
              */
             if (!isset($arr['evClickThroughStatus'])) {
@@ -507,7 +509,7 @@ class Util
 
         if ($responseArray['errorCode'] == 0) {
             $result = new GetDCVEMailAddressListResult();
-            
+
             if (isset($responseArray['whois_email'][0]) && $responseArray['whois_email'][0] == 'none') {
                 unset($responseArray['whois_email'][0]);
             }
@@ -659,8 +661,8 @@ class Util
      * @throws Model\Exception\UnknownApiException
      * @throws Model\Exception\UnknownException
      */
-    public function webHostReport(array $params) {
-
+    public function webHostReport(array $params)
+    {
         if (empty($params['lastResultNo'])) {
             $params['lastResultNo'] = 10;
         }


### PR DESCRIPTION
This is the fix for Issue #12 

I went about it differently than I suggested in the issue after seeing your own code style just below it. I'm just checking if the response property is set and adding it to the response object if it is.

I apologize for the whitespace changes--my editor got opinionated.